### PR TITLE
Define RPATH with relative paths

### DIFF
--- a/CMake/gnu.toolchain.cmake
+++ b/CMake/gnu.toolchain.cmake
@@ -133,4 +133,6 @@ macro(find_host_package)
  __cmake_find_root_restore()
 endmacro()
 
-set(CMAKE_SKIP_RPATH FALSE CACHE BOOL "If set, runtime paths are not added when using shared libraries.")
+set(CMAKE_SKIP_RPATH FALSE BOOL "If set, runtime paths are not added when using shared libraries.")
+SET(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE) # make it so rpath is defined relatively to build folder, so we can just relocate it
+


### PR DESCRIPTION
This lets us just copy the build folder and have the exe still link to our wiringPi shared library in the same build directory